### PR TITLE
refactor(components): replace card implementation with reusable card-list component

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -21,6 +21,6 @@ module.exports = {
     'subject-min-length': [2, 'always', 10],
     'subject-full-stop': [2, 'never', '.'],
     'body-leading-blank': [2, 'always'],
-    'body-max-line-length': [2, 'always', 100],
+    'body-max-line-length': [2, 'always',100],
   },
 };

--- a/src/core/shared/components/CardList.tsx
+++ b/src/core/shared/components/CardList.tsx
@@ -14,7 +14,8 @@ type RootStackParamList = {
 
 type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
 
-interface CardListProps extends Omit<CardProps, 'onPress' | 'style'> {
+interface CardListProps
+  extends Omit<CardProps, 'onPress' | 'style' | 'children'> {
   item: Favorite | Item;
   navigation: NavigationProp;
   onPress?: () => void;

--- a/src/core/shared/components/CardList.tsx
+++ b/src/core/shared/components/CardList.tsx
@@ -1,0 +1,93 @@
+import {StyleSheet} from 'react-native';
+import React, {useState} from 'react';
+import {Card, CardProps} from 'react-native-paper';
+import Item from '../../../features/plugins/data/model/item/Item';
+import {NativeStackNavigationProp} from '@react-navigation/native-stack';
+import {Favorite} from '../../../features/library/domain/entities/Favorite';
+import LinearGradient from 'react-native-linear-gradient';
+
+type RootStackParamList = {
+  details: {
+    item: Item;
+  };
+};
+
+type NavigationProp = NativeStackNavigationProp<RootStackParamList>;
+
+interface CardListProps extends Omit<CardProps, 'onPress' | 'style'> {
+  item: Favorite | Item;
+  navigation: NavigationProp;
+  onPress?: () => void;
+  style?: CardProps['style'];
+}
+const CardList: React.FC<CardListProps> = ({
+  item,
+  navigation,
+  onPress,
+  style,
+  ...props
+}) => {
+  const [showPlaceholder, setShowPlaceholder] = useState(false);
+
+  const handlePress = () => {
+    if (onPress) {
+      onPress();
+    } else {
+      navigation.navigate('details', {item: 'item' in item ? item.item : item});
+    }
+  };
+
+  const cardStyle = [styles.card, style];
+
+  return (
+    <Card style={cardStyle} onPress={handlePress} {...props}>
+      <Card.Cover
+        source={
+          showPlaceholder
+            ? require('../../../../assets/images/placeholders/tall.jpg')
+            : {uri: 'item' in item ? item.item.imageUrl : item.imageUrl}
+        }
+        onError={() => setShowPlaceholder(true)}
+      />
+      <LinearGradient
+        colors={['rgba(0,0,0,0.8)', 'transparent']}
+        start={{x: 0, y: 1}}
+        end={{x: 0, y: 0.3}}
+        style={styles.gradient}
+      />
+      <Card.Title
+        title={'item' in item ? item.item.name : item.name}
+        titleStyle={styles.cardTitle}
+        titleNumberOfLines={2}
+        style={styles.cardTitleContainer}
+      />
+    </Card>
+  );
+};
+
+export default CardList;
+
+const styles = StyleSheet.create({
+  card: {
+    marginRight: 8,
+    position: 'relative',
+    overflow: 'hidden',
+  },
+  gradient: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    height: '100%',
+  },
+  cardTitle: {
+    fontSize: 14,
+    fontWeight: 'bold',
+  },
+  cardTitleContainer: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+  },
+});

--- a/src/features/library/presentation/components/LibraryPageItem.tsx
+++ b/src/features/library/presentation/components/LibraryPageItem.tsx
@@ -1,6 +1,4 @@
-import {View, StyleSheet} from 'react-native';
 import React from 'react';
-import {Card, Text} from 'react-native-paper';
 import Item from '../../../plugins/data/model/item/Item';
 import {NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {useNavigation} from '@react-navigation/core';

--- a/src/features/library/presentation/components/LibraryPageItem.tsx
+++ b/src/features/library/presentation/components/LibraryPageItem.tsx
@@ -5,6 +5,7 @@ import Item from '../../../plugins/data/model/item/Item';
 import {NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {useNavigation} from '@react-navigation/core';
 import {Favorite} from '../../domain/entities/Favorite';
+import CardList from '../../../../core/shared/components/CardList';
 
 type DetailsScreenProps = {
   details: {
@@ -16,38 +17,8 @@ const LibraryPageItem = ({item}: {item: Favorite}) => {
   const navigation =
     useNavigation<NativeStackNavigationProp<DetailsScreenProps>>();
 
-  const [showPlaceholder, setShowPlaceholder] = React.useState(false);
 
-  return (
-    <Card
-      style={styles.card}
-      onPress={() => navigation.navigate('details', {item: item.item})}>
-      <Card.Cover
-        source={
-          showPlaceholder
-            ? require('../../../../../assets/images/placeholders/tall.jpg')
-            : {uri: item.item.imageUrl}
-        }
-        onError={() => setShowPlaceholder(true)}
-      />
-      <Card.Title
-        title={item.item.name}
-        titleStyle={{textAlign: 'center'}}
-        titleNumberOfLines={2}
-      />
-      <Card.Content>
-        <Text variant="bodyMedium" style={{textAlign: 'center'}}>
-          {item.item.description}
-        </Text>
-      </Card.Content>
-    </Card>
-  );
+  return <CardList item={item} navigation={navigation}/>;
 };
 
 export default LibraryPageItem;
-
-const styles = StyleSheet.create({
-  card: {
-    marginRight: 8,
-  },
-});

--- a/src/features/search/presentation/components/CategorySwiper/CategorySwiper.tsx
+++ b/src/features/search/presentation/components/CategorySwiper/CategorySwiper.tsx
@@ -1,4 +1,4 @@
-import {View, ScrollView, Dimensions, StyleSheet} from 'react-native';
+import {View, ScrollView, StyleSheet} from 'react-native';
 import React from 'react';
 import Category from '../../../../plugins/data/model/item/Category';
 import {IconButton, Text, useTheme} from 'react-native-paper';

--- a/src/features/search/presentation/components/CategorySwiper/CategorySwiperItem.tsx
+++ b/src/features/search/presentation/components/CategorySwiper/CategorySwiperItem.tsx
@@ -1,6 +1,6 @@
-import {View, StyleSheet} from 'react-native';
+import {StyleSheet} from 'react-native';
 import React from 'react';
-import {Card, Text, useTheme} from 'react-native-paper';
+import {useTheme} from 'react-native-paper';
 import Item from '../../../../plugins/data/model/item/Item';
 import {NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {useNavigation} from '@react-navigation/core';
@@ -21,12 +21,18 @@ const CategorySwiperItem = ({item}: {item: Item}) => {
 
   const {setBottomSheetVisible} = useSearchPageDataStore();
 
-  return <CardList item={item} navigation={navigation} style={{...styles.card, backgroundColor: theme.colors.surface}}
+  return (
+    <CardList
+      item={item}
+      navigation={navigation}
+      style={{...styles.card, backgroundColor: theme.colors.surface}}
       mode="contained"
       onPress={() => {
         setBottomSheetVisible(false);
         navigation.navigate('details', {item: item});
-      }}/>;
+      }}
+    />
+  );
 };
 
 export default CategorySwiperItem;

--- a/src/features/search/presentation/components/CategorySwiper/CategorySwiperItem.tsx
+++ b/src/features/search/presentation/components/CategorySwiper/CategorySwiperItem.tsx
@@ -5,6 +5,7 @@ import Item from '../../../../plugins/data/model/item/Item';
 import {NativeStackNavigationProp} from '@react-navigation/native-stack';
 import {useNavigation} from '@react-navigation/core';
 import {useSearchPageDataStore} from '../../state/useSearchPageDataStore';
+import CardList from '../../../../../core/shared/components/CardList';
 
 type DetailsScreenProps = {
   details: {
@@ -16,40 +17,16 @@ const CategorySwiperItem = ({item}: {item: Item}) => {
   const navigation =
     useNavigation<NativeStackNavigationProp<DetailsScreenProps>>();
 
-  const [showPlaceholder, setShowPlaceholder] = React.useState(false);
-
   const theme = useTheme();
 
   const {setBottomSheetVisible} = useSearchPageDataStore();
 
-  return (
-    <Card
-      style={{...styles.card, backgroundColor: theme.colors.surface}}
+  return <CardList item={item} navigation={navigation} style={{...styles.card, backgroundColor: theme.colors.surface}}
       mode="contained"
       onPress={() => {
         setBottomSheetVisible(false);
         navigation.navigate('details', {item: item});
-      }}>
-      <Card.Cover
-        source={
-          showPlaceholder
-            ? require('../../../../../../assets/images/placeholders/tall.jpg')
-            : {uri: item.imageUrl}
-        }
-        onError={() => setShowPlaceholder(true)}
-      />
-      <Card.Title
-        title={item.name}
-        titleStyle={{textAlign: 'center'}}
-        titleNumberOfLines={2}
-      />
-      <Card.Content>
-        <Text variant="bodyMedium" style={{textAlign: 'center'}}>
-          {item.description}
-        </Text>
-      </Card.Content>
-    </Card>
-  );
+      }}/>;
 };
 
 export default CategorySwiperItem;


### PR DESCRIPTION
### Summary

Introduced a reusable `CardList` component to centralize card rendering across the app and reduce duplication.

### Changes

* **Added** `CardList` in `src/core/shared/components/CardList.tsx` to handle item display, navigation, and placeholder images.
* **Refactored**:

  * `LibraryPageItem.tsx`: Replaced custom cards with `CardList`; removed redundant state/styles.
  * `CategorySwiperItem.tsx`: Simplified card rendering using `CardList`.